### PR TITLE
feat: Add OpenAPI generation command

### DIFF
--- a/src/Console/Commands/GenerateOpenApiDocsCommand.php
+++ b/src/Console/Commands/GenerateOpenApiDocsCommand.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WhileSmart\LaravelPluginEngine\Console\Commands;
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+class GenerateOpenApiDocsCommand extends PluginCommand
+{
+    protected $signature = 'plugin:openapi {plugins?* : The names of the plugins to generate documentation for. Leave empty to generate for all plugins}';
+
+    protected $description = 'Generate and merge OpenAPI documentation for all installed plugins.';
+
+    public function handle(): int
+    {
+        $requestedPlugins = $this->argument('plugins');
+        $targetPlugins = collect();
+
+        if (empty($requestedPlugins)) {
+            $this->info('Discovering all valid plugins...');
+            $allPlugins = $this->pluginManager->discover();
+            $targetPlugins = $allPlugins->filter(function ($plugin) {
+                $validation = $this->pluginManager->validatePlugin($plugin);
+                if (! $validation['is_valid']) {
+                    $pluginId = $plugin['path'] ?? 'unknown plugin';
+                    $this->warn("Skipping invalid plugin: {$pluginId} - Reason: {$validation['error']}");
+                }
+
+                return $validation['is_valid'];
+            });
+        } else {
+            $this->info('Resolving requested plugins...');
+            foreach ($requestedPlugins as $pluginName) {
+                try {
+                    // resolvePlugin already handles validation and throws an exception
+                    $targetPlugins->push($this->resolvePlugin($pluginName));
+                } catch (\RuntimeException $e) {
+                    $this->error($e->getMessage());
+                }
+            }
+        }
+
+        if (empty($targetPlugins)) {
+            $this->info('No valid plugins found to generate documentation for.');
+
+            return self::SUCCESS;
+        }
+
+        $outputDir = public_path('docs');
+        $openapiBin = base_path('vendor/bin/openapi');
+
+        if (! is_dir($outputDir)) {
+            mkdir($outputDir, 0755, true);
+        }
+
+        $generatedFiles = [];
+
+        foreach ($targetPlugins as $plugin) {
+            $pluginName = $plugin['name'];
+            $pluginId = $plugin['id'];
+            $pluginPath = $plugin['path'];
+            $outputFile = "{$outputDir}/{$pluginId}.json";
+
+            $this->info("Generating OpenAPI for '{$pluginName}' plugin...");
+
+            $bootstrapPath = dirname(__DIR__, 2).'/bootstrap.php';
+
+            $process = new Process([$openapiBin, $pluginPath, '--bootstrap', $bootstrapPath, '--output', $outputFile]);
+
+            try {
+                $process->mustRun();
+                $this->info("Successfully generated OpenAPI for '{$pluginName}' plugin.");
+                if (file_exists($outputFile)) {
+                    $this->info("Generated {$outputFile}");
+                    $generatedFiles[] = $outputFile;
+                }
+            } catch (ProcessFailedException $exception) {
+                $this->error("Failed to generate OpenAPI for '{$pluginName}' plugin.");
+                $this->error('Error Output:');
+                $this->line($exception->getProcess()->getErrorOutput());
+                $this->error('Standard Output:');
+                $this->line($exception->getProcess()->getOutput());
+            }
+        }
+
+        if (empty($generatedFiles)) {
+            $this->info('No plugin documentation was generated.');
+
+            return self::SUCCESS;
+        }
+
+        // If no specific plugins were requested, always merge into a single file.
+        if (empty($requestedPlugins)) {
+            $this->info('Merging plugin OpenAPI files...');
+            $base = json_decode(file_get_contents(array_shift($generatedFiles)), true);
+
+            foreach ($generatedFiles as $file) {
+                $pluginData = json_decode(file_get_contents($file), true);
+                if (isset($pluginData['paths'])) {
+                    $base['paths'] = array_merge($base['paths'] ?? [], $pluginData['paths']);
+                }
+                if (isset($pluginData['components'])) {
+                    $base['components'] = array_merge_recursive($base['components'] ?? [], $pluginData['components']);
+                }
+                if (isset($pluginData['tags'])) {
+                    $base['tags'] = array_merge($base['tags'] ?? [], $pluginData['tags']);
+                }
+                unlink($file);
+            }
+
+            $finalOutputFile = "{$outputDir}/plugins.json";
+            file_put_contents($finalOutputFile, json_encode($base, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            $this->info("Successfully merged plugin documentation into {$finalOutputFile}");
+        } else {
+            // If specific plugins were requested, the individual files are the final output.
+            $this->info('Plugin documentation generated successfully.');
+            foreach ($generatedFiles as $file) {
+                $this->line("  - Generated: {$file}");
+            }
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Providers/PluginServiceProvider.php
+++ b/src/Providers/PluginServiceProvider.php
@@ -19,6 +19,7 @@ class PluginServiceProvider extends ServiceProvider
         \WhileSmart\LaravelPluginEngine\Console\Commands\InfoCommand::class,
         \WhileSmart\LaravelPluginEngine\Console\Commands\InstallCommand::class,
         \WhileSmart\LaravelPluginEngine\Console\Commands\ListCommand::class,
+        \WhileSmart\LaravelPluginEngine\Console\Commands\GenerateOpenApiDocsCommand::class,
     ];
 
     /**
@@ -63,7 +64,7 @@ class PluginServiceProvider extends ServiceProvider
     /**
      * Bootstrap any application services.
      */
-    public function boot()
+    public function boot(): void
     {
         $this->publishConfig();
         $this->registerPlugins();

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,0 +1,40 @@
+<?php
+
+// Determine the project root directory by navigating up from this script's location.
+$projectRoot = dirname(__DIR__, 2);
+
+$autoloader = require $projectRoot.'/vendor/autoload.php';
+
+$pluginsDir = $projectRoot.'/plugins';
+
+if (! is_dir($pluginsDir)) {
+    return;
+}
+
+$pluginJsonFiles = glob($pluginsDir.'/*/plugin.json');
+
+foreach ($pluginJsonFiles as $file) {
+    $content = @file_get_contents($file);
+    if ($content === false) {
+        error_log("Plugin Autoload Bootstrap: Could not read file: {$file}");
+
+        continue;
+    }
+
+    $pluginConfig = json_decode($content, true);
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        error_log("Plugin Autoload Bootstrap: Invalid JSON in file: {$file}. Error: ".json_last_error_msg());
+
+        continue;
+    }
+
+    // Ensure config is a valid array and namespace is set before proceeding.
+    if (is_array($pluginConfig) && ! empty($pluginConfig['namespace'])) {
+        $namespace = rtrim($pluginConfig['namespace'], '\\').'\\';
+        $path = dirname($file).'/src';
+
+        if (is_dir($path)) {
+            $autoloader->addPsr4($namespace, $path);
+        }
+    }
+}


### PR DESCRIPTION
Adds a new Artisan command `plugin:openapi` to generate OpenAPI documentation for all installed plugins.

The command uses a dynamic bootstrap script to discover and register plugin namespaces, allowing the scanner to correctly parse annotations.

Individual OpenAPI JSON files are generated for each plugin and then merged into a single `public/docs/plugins.json` file.