### PR TITLE
fix: Use Composer InstalledVersions for root path

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,9 +1,21 @@
 <?php
 
-// Determine the project root directory by navigating up from this script's location.
-$projectRoot = dirname(__DIR__, 2);
+// Use Composer's InstalledVersions to determine the project root.
+// This is a more reliable and performant method than traversing the filesystem.
+if (class_exists(\Composer\InstalledVersions::class)) {
+    $projectRoot = \Composer\InstalledVersions::getRootPackage()['install_path'];
+} else {
+    // If Composer 2's InstalledVersions is not available, we cannot reliably determine the project root.
+    // This typically indicates an incomplete Composer setup or an environment not using Composer 2+.
+    throw new \RuntimeException('Cannot determine project root. Please ensure Composer is used and its dependencies are installed, or that you are using Composer 2.');
+}
 
-$autoloader = require $projectRoot.'/vendor/autoload.php';
+// Require the project's autoloader.
+$autoloaderPath = $projectRoot.'/vendor/autoload.php';
+if (! file_exists($autoloaderPath)) {
+    throw new \RuntimeException('Could not find vendor/autoload.php. Please run composer install.');
+}
+$autoloader = require $autoloaderPath;
 
 $pluginsDir = $projectRoot.'/plugins';
 


### PR DESCRIPTION
Refactors the project root discovery to use Composer's InstalledVersions class. This provides a more direct, performant, and reliable method than filesystem traversal, ensuring the correct project root is identified when the package is used as a dependency.